### PR TITLE
fix: small typo fix in Amazon link

### DIFF
--- a/themes/personal/layouts/partials/book.html
+++ b/themes/personal/layouts/partials/book.html
@@ -32,7 +32,7 @@
         </p>
         <p>
             <a href="https://www.amazon.com/dp/1726146456/ref=sr_1_1?ie=UTF8&qid=1535197414&sr=8-1&keywords=professional+front-end+architecture&pldnSite=1"
-                target="_blank" class="button success" rel="noopener noreferrer">Got to Amazon page...</a>
+                target="_blank" class="button success" rel="noopener noreferrer">Go to Amazon page...</a>
         </p>
     </div>
 </section>


### PR DESCRIPTION
Pull request to suggest a small typo fix in Amazon Link.
Fixes the issue in following image - 
<img width="1052" alt="Screen Shot 2020-12-07 at 11 41 39 PM" src="https://user-images.githubusercontent.com/42949670/101440857-c2b15580-38e5-11eb-9bf8-cf040d8df9b8.png">
